### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,7 +126,7 @@ jobs:
       id: vars
       run: echo ::set-output name=relase_tag::$(grep version setup.py | cut -d "\"" -f2)
     - name: Create a Release
-      uses: elgohr/Github-Release-Action@master
+      uses: elgohr/Github-Release-Action@v4
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}      
       with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore